### PR TITLE
Fix typo: grin-wallet.md --> grincc-wallet.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Repository dedicated for financial transparency of the Grin Community Fund
 | [Addresses](/addresses.md) | The list of cryptocurrency addresses associated to the project. |
 | [Transparency reports](/reports) | Financial transparency reports on a quarterly basis. |
 | [Financial logs](/spending_log.csv) | Line by line details of income and spending. |
-| [Grin wallet transactions](/grin-wallet.md) | Snapshot of the transaction log of the Grin Community wallet. |
+| [Grin wallet transactions](/grincc-wallet.md) | Snapshot of the transaction log of the Grin Community wallet. |


### PR DESCRIPTION
Fix typo in README.md 
from grin-wallet.md to --> grincc-wallet.md